### PR TITLE
Replaced 'arch' tool with posix-compliant 'uname -m'

### DIFF
--- a/Dockerfile-arm
+++ b/Dockerfile-arm
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get install -y gdb gdbserver strace vim upx python3-dev poppler-utils ruby netcat bsdmainutils sshpass gawk bash-completion && \
     apt-get install -y --no-install-recommends libffi-dev && \
     apt-get install -y radare2 && \
-    apt-get install -y no-install-recommends binwalk && \
+    apt-get install -y --no-install-recommends binwalk && \
     apt-get install -y john foremost sqlmap && \
     apt-get clean
 

--- a/build.sh
+++ b/build.sh
@@ -5,9 +5,10 @@ set -xeuo pipefail
 image_name=${IMAGE_NAME:-kali}
 bindir=${HOME}/.local/bin
 
-case "$(arch)" in
+case "$(uname -m)" in
     x86_64) my_arch=amd64 ;;
-    arm64) my_arch=arm64 ;;
+    arm64 | aarch64 | armv8 | armv9) my_arch=arm64 ;;
+    armhf | armv7l | armv7 | armv6) my_arch=arm ;;
     *) my_arch= ;;
 esac
 


### PR DESCRIPTION
- "build.sh" is failing on host distros which don't include 'arch' as a coreutil => replaced it with posix-compliant "uname -m" 
- Added a little flexibility on auto detected targets "arm" and "arm64" based on the possible return values of "uname -m" on this platform