### PR TITLE
fix run.sh and dockerfile-arm (pip3/capstone)

### DIFF
--- a/Dockerfile-arm
+++ b/Dockerfile-arm
@@ -26,13 +26,16 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
 # get last version of pip
-RUN curl -sL https://bootstrap.pypa.io/get-pip.py | python3 -
+RUN apt-get install -y --no-install-recommends python3-pip && \
+    python3 -m pip config set global.break-system-packages true && \
+    pip3 --no-cache-dir install --upgrade pip
 
 # the tools
 RUN set -ex && \
     mkdir -p /opt/tools && \
     \
     # http://docs.pwntools.com/ (+ ROPgadget)
+    pip3 --no-cache-dir install --upgrade capstone && \
     pip3 --no-cache-dir install --upgrade unicorn && \
     pip3 --no-cache-dir install --upgrade pwntools && \
     \

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 set -Eeuo pipefail
 
 progname=$(basename "${BASH_SOURCE[0]}")
-image_name=dgse
+image_name=kali
 
 # find the first free container id
 find_name()


### PR DESCRIPTION
- Fix container name in run.sh (with default value "kali")
- Usage of kali-packaged pip
- Adapted pip's configuration to force system-wide install (no venv needed)
- Added explicit capstone install (broken pwntools dependancy)

No changes were made to non-arm Dockerfiles (only tested on apple silicon)